### PR TITLE
Setup de auth nas rotas API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,14 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-authorization</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/br/com/inkinvite/infrastructure/security/KeycloakProvider.java
+++ b/src/main/java/br/com/inkinvite/infrastructure/security/KeycloakProvider.java
@@ -10,9 +10,8 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class KeycloakProvider {
-
     @Inject
-    @ConfigProperty(name = "REALM")
+    @ConfigProperty(name = "URL_ONLY")
     private String serverURL;
 
     @Inject

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,3 +42,4 @@ quarkus.oidc.client-id=${CLIENT_ID}
 quarkus.oidc.credentials.secret=${CLIENT_SECRET}
 quarkus.oidc.application-type=service
 quarkus.oidc.realm=${REALM_NAME}
+quarkus.oidc.tls.verification=none


### PR DESCRIPTION
Criação de auth para as rotas APIs.

1. Instação das LIBs necessárias;
2. Atualização do application.properties com novos valores;
3. Pequena refatoração da classe KeycloakProvider para usar uma nova variável de ambiente ao invés do caminho completo do Keycloak;

Para se usar a anotação, basta colocar o decorator `@RolesAllowed("role")` sobre a classe ou método a ser protegido. Para se usar permissão basta usar o decorator `@PermissionsAllowed("permissão")` da mesma maneira.